### PR TITLE
fix: detach status/guidelines blocks from workers and remove broken import

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -25,7 +25,6 @@ from .config import (
 from .mcp_setup import setup_mcp_servers, get_mcp_tool_ids, get_mcp_tool_names, MCPServerInfo
 from .research_agent import create_research_agent
 from .task_agent import create_task_agent
-from .coding_agent import create_coding_agent
 from .homeassistant_agent import create_homeassistant_agent
 from .personal_assistant import create_personal_assistant
 
@@ -51,7 +50,6 @@ __all__ = [
     # Agent creators
     "create_research_agent",
     "create_task_agent",
-    "create_coding_agent",
     "create_homeassistant_agent",
     "create_personal_assistant",
 ]

--- a/agents/homeassistant_agent.py
+++ b/agents/homeassistant_agent.py
@@ -111,7 +111,7 @@ def create_homeassistant_agent(
             {"label": "persona", "value": PERSONA},
             {"label": "human", "value": HUMAN},
         ],
-        block_ids=[shared.guidelines_block_id, shared.status_block_id],
+        block_ids=[],
         tags=["worker", "smarthome"],
         tools=["archival_memory_insert", "archival_memory_search"],
         tool_ids=mcp_tool_ids,

--- a/agents/research_agent.py
+++ b/agents/research_agent.py
@@ -96,7 +96,7 @@ def create_research_agent(
             {"label": "persona", "value": PERSONA},
             {"label": "human", "value": HUMAN},
         ],
-        block_ids=[shared.guidelines_block_id, shared.status_block_id],
+        block_ids=[],
         tags=["worker", "research"],
         tools=["web_search", "fetch_webpage", "archival_memory_insert", "archival_memory_search"],
         tool_ids=mcp_tool_ids,

--- a/agents/task_agent.py
+++ b/agents/task_agent.py
@@ -101,7 +101,7 @@ def create_task_agent(
             {"label": "persona", "value": PERSONA},
             {"label": "human", "value": HUMAN},
         ],
-        block_ids=[shared.guidelines_block_id, shared.status_block_id],
+        block_ids=[],
         tags=["worker", "task"],
         tools=["web_search", "archival_memory_insert", "archival_memory_search"],
         tool_ids=mcp_tool_ids,


### PR DESCRIPTION
## Summary

Partial fix for #1 (items 1 & 3) plus a bonus import bug fix.

---

## Change 1 — Detach `status` and `guidelines` blocks from worker agents (Issue #1, items 1 & 3)

Worker agents (Research, Task, HomeAssistant) no longer have `status_block_id` or `guidelines_block_id` attached. Their `block_ids` argument is now `[]`.

**Why:** Workers don't need either block in-context on every step:
- The `status` block is only needed by the PA (supervisor) for tracking delegation state
- Worker personas already contain their own inline coordination instructions, making the shared `guidelines` block redundant for them

The PA (`personal_assistant.py`) is unchanged — it retains both blocks as required.

**Files changed:**
- `agents/research_agent.py`
- `agents/task_agent.py`
- `agents/homeassistant_agent.py`

---

## Change 2 — Remove broken `coding_agent` import

`agents/__init__.py` was importing `create_coding_agent` from `agents/coding_agent.py`, which does not exist. This caused an `ImportError` on any `import agents` call. The import and its `__all__` entry have been removed.

The coding agent functionality has been replaced by the `execute_coding_task` tool on the PA, so this import is no longer needed.

**File changed:**
- `agents/__init__.py`

---

## Remaining Issue #1 items (not in this PR)
- Item 2: Slim `status` block to active-only (needs archival-move logic)
- Item 4: Slim PA persona (move routing/delegation examples → archival seeds)
- Item 5: Follows from items 1–4 (block audit complete once all items done)