### PR TITLE
fix: status block size management and slim PA persona (issue #1 items 2 & 4)

### DIFF
--- a/agents/config.py
+++ b/agents/config.py
@@ -348,7 +348,8 @@ User Preferences:
 - (Updated by Personal Assistant as user preferences are learned)
 """.strip()
 
-STATUS_DEFAULT = """Task Status:
+STATUS_DEFAULT = """# Keep this block to 3–5 active lines. Archive completed entries to archival memory (tag: status-history) before adding new ones.
+Task Status:
 - (Agents update this block when starting/completing tasks)
 
 Recent Activity:

--- a/agents/personal_assistant.py
+++ b/agents/personal_assistant.py
@@ -150,13 +150,9 @@ Example acknowledgments:
 ROUTING EXAMPLES:
 
 - "Research quantum computing" -> send_message_to_agents_matching_tags (research)
-- "Create a GitHub issue" -> send_message_to_agents_matching_tags (task)
-- "Fix the failing tests" -> execute_coding_task
-- "Review the auth module" -> execute_coding_task
-- "Create a release for v2.0" -> execute_coding_task
-- "Clone repo X and run tests" -> execute_coding_task
+- "Create a GitHub issue / Take notes" -> send_message_to_agents_matching_tags (task)
+- "Fix tests / Review code / Create a release" -> execute_coding_task
 - "Add a light to my dashboard" -> send_message_to_agents_matching_tags (smarthome)
-- "Take notes on this meeting" -> send_message_to_agents_matching_tags (task)
 
 SHARED KNOWLEDGE:
 
@@ -186,29 +182,16 @@ COORDINATION:
 - Check and update the status block to track what workers are doing
 - Update status when delegating: "PA: Delegating research on X to Research Agent"
 - Check status to avoid duplicate work or see what's already in progress
+- Keep the status block to 3–5 active lines max. Before adding a new entry, move any COMPLETED entries to archival memory with tag [status-history], then update the block.
 
 CODING TASK EXAMPLES:
 
-When calling execute_coding_task, include the repo URL, branch (if relevant), and 
+When calling execute_coding_task, include the repo URL, branch (if relevant), and
 clear description. The coding agent has skills that guide it on best practices.
 
-Bug fix with PR:
-  execute_coding_task("Fix issue #42 in https://github.com/org/repo. Create a PR with the fix.")
-
-Multi-issue PRs:
-  execute_coding_task("Fix issues #10, #11, #12 in https://github.com/org/repo. Create ONE PR per issue. Check for existing PRs before creating new ones.")
-
-Code review (read-only):
-  execute_coding_task("Review the authentication module in https://github.com/org/repo. Report security concerns and code quality issues. Do not make changes.")
-
-Testing:
-  execute_coding_task("Run the test suite in https://github.com/org/repo. Report failures and analyze root causes.")
-
-Release creation:
-  execute_coding_task("Create release v2.1.0 in https://github.com/org/repo with auto-generated changelog.")
-
-Refactoring:
-  execute_coding_task("Refactor the database layer in https://github.com/org/repo to use connection pooling. Create a PR.")
+- Bug fix with PR: "Fix issue #42 in https://github.com/org/repo. Create a PR."
+- Multi-issue PRs: "Fix issues #10, #11, #12 in https://github.com/org/repo. ONE PR per issue. Check for existing PRs first."
+- Code review (read-only): "Review the auth module in https://github.com/org/repo. Report issues. Do not make changes."
 
 BEST PRACTICES:
 


### PR DESCRIPTION
Closes #1

## Summary

Implements the remaining open items from issue #1 (items 2 and 4). Items 1 and 3 were completed in PR #7. Item 5 (per-agent block audit) is satisfied by the combination of this PR and PR #7.

---

## Item 2 — Status block size management

### `agents/config.py` — STATUS_DEFAULT
Added an explicit instruction at the top of the `status` block value directing the PA to keep the block to 3–5 active lines and archive completed entries to archival memory (tag: `[status-history]`) before adding new ones.

### `agents/personal_assistant.py` — COORDINATION section
Added a new rule to the PA persona's COORDINATION section reinforcing the same policy: move completed entries to archival memory with `[status-history]` before updating the block; keep it to 3–5 lines max.

---

## Item 4 — Slim PA persona

Trimmed the two most token-expensive sections of the PA PERSONA:

### ROUTING EXAMPLES
Reduced from ~8 bullets to 4 representative examples (one per worker type + coding). The full tag details are already documented in the AVAILABLE WORKERS section.

### CODING TASK EXAMPLES
Reduced from 5–6 multi-line code block examples to 3 compact single-line examples. Removes the verbatim inline code blocks that duplicated information already present in the DELEGATION RULES section.

The AVAILABLE WORKERS, DELEGATION RULES, and BEST PRACTICES sections are unchanged.

---

## Item 5 — Per-agent block attachment audit (complete)

Combined with PR #7 (already merged/in review), the block attachment state is now:
- **PA:** `persona`, `human`, `status`, `guidelines` ✅
- **Research worker:** `block_ids=[]` ✅
- **Task worker:** `block_ids=[]` ✅
- **HomeAssistant worker:** `block_ids=[]` ✅