### PR TITLE
fix: attach status block to all worker agents

### DIFF
--- a/agents/homeassistant_agent.py
+++ b/agents/homeassistant_agent.py
@@ -111,7 +111,7 @@ def create_homeassistant_agent(
             {"label": "persona", "value": PERSONA},
             {"label": "human", "value": HUMAN},
         ],
-        block_ids=[],
+        block_ids=[shared.guidelines_block_id, shared.status_block_id],
         tags=["worker", "smarthome"],
         tools=["archival_memory_insert", "archival_memory_search"],
         tool_ids=mcp_tool_ids,

--- a/agents/research_agent.py
+++ b/agents/research_agent.py
@@ -102,7 +102,7 @@ def create_research_agent(
             {"label": "persona", "value": PERSONA},
             {"label": "human", "value": HUMAN},
         ],
-        block_ids=[shared.monitoring_block_id],
+        block_ids=[shared.guidelines_block_id, shared.status_block_id, shared.monitoring_block_id],
         tags=["worker", "research"],
         tools=["web_search", "fetch_webpage", "archival_memory_insert", "archival_memory_search"],
         tool_ids=mcp_tool_ids,

--- a/agents/task_agent.py
+++ b/agents/task_agent.py
@@ -101,7 +101,7 @@ def create_task_agent(
             {"label": "persona", "value": PERSONA},
             {"label": "human", "value": HUMAN},
         ],
-        block_ids=[],
+        block_ids=[shared.guidelines_block_id, shared.status_block_id],
         tags=["worker", "task"],
         tools=["web_search", "archival_memory_insert", "archival_memory_search"],
         tool_ids=mcp_tool_ids,


### PR DESCRIPTION
## Bug

Worker agents (`ResearchAgent`, `TaskAgent`, `HomeAssistantAgent`) all have persona instructions telling them to _"Update the status block when starting/completing tasks"_, but the `status` block was never actually attached to them via `block_ids`. As a result, their status writes silently failed (the block wasn't in their core memory, so the update was never persisted) — making cross-agent coordination unreliable.

The same issue affected the `guidelines` block: workers referenced coordination rules and user preferences from it, but couldn't see it because it also wasn't attached.

| Agent | Before | After |
|---|---|---|
| `PersonalAssistant` | `[guidelines, status, monitoring, todo]` | _(unchanged)_ |
| `ResearchAgent` | `[monitoring]` | `[guidelines, status, monitoring]` |
| `TaskAgent` | `[]` | `[guidelines, status]` |
| `HomeAssistantAgent` | `[]` | `[guidelines, status]` |

## Fix

- **`research_agent.py`** — add `guidelines_block_id` and `status_block_id`. Already had `monitoring_block_id` (its persona explicitly references the monitoring block for scheduled task instructions, so that stays).
- **`task_agent.py`** — add `guidelines_block_id` and `status_block_id` (was an empty list).
- **`homeassistant_agent.py`** — add `guidelines_block_id` and `status_block_id` (was an empty list).

All workers now share the **same block instances** as the PA (`shared.status_block_id`, `shared.guidelines_block_id`), so every agent reads and writes the same live state — consistent with how the shared archive is handled.

## Test plan

- [ ] Run `create_all.py` against a fresh Letta server — verify `ResearchAgent`, `TaskAgent`, and `HomeAssistantAgent` are created with `guidelines` and `status` blocks visible in their core memory
- [ ] Run `create_all.py` a second time (idempotent path) — verify the merge logic in `find_or_create_agent` preserves the new block attachments without evicting existing blocks
- [ ] Send a task to a worker agent and confirm its status update appears in the shared `status` block (visible to the PA and other workers)

👾 Generated with [Letta Code](https://letta.com)