### PR TITLE
fix: wire get_agent_model() into all agent creation functions

### DIFF
--- a/agents/create_all.py
+++ b/agents/create_all.py
@@ -32,7 +32,7 @@ Environment variables:
     DOCUMENT_STORE_PATH     - Path to document store directory (optional)
 """
 
-from .config import get_config, get_client, create_shared_resources, build_mcp_tool_rules
+from .config import get_config, get_client, get_agent_model, create_shared_resources, build_mcp_tool_rules
 from .mcp_setup import setup_mcp_servers, get_mcp_tool_ids, get_mcp_tool_names
 from .research_agent import create_research_agent
 from .task_agent import create_task_agent
@@ -65,7 +65,11 @@ def create_all_agents():
     client = get_client(config)
 
     print(f"Connecting to Letta at {config.base_url}")
-    print(f"Using model: {config.model}")
+    print(f"Using model: {config.model} (global default)")
+    print(f"  PA:            {get_agent_model('pa', config)}")
+    print(f"  Research:      {get_agent_model('research', config)}")
+    print(f"  Task:          {get_agent_model('task', config)}")
+    print(f"  HomeAssistant: {get_agent_model('homeassistant', config)}")
     print(f"Using embedding: {config.embedding}")
     print()
 

--- a/agents/homeassistant_agent.py
+++ b/agents/homeassistant_agent.py
@@ -19,6 +19,7 @@ from .config import (
     AgentConfig,
     SharedResources,
     WORKER_TOOL_RULES,
+    get_agent_model,
     find_or_create_agent,
     ensure_archive_attached,
 )
@@ -100,13 +101,20 @@ def create_homeassistant_agent(
     Returns:
         Tuple of (agent, was_created)
     """
+    # Resolve per-agent model override (falls back to config.model if LETTA_MODEL_HOMEASSISTANT is not set)
+    agent_config = AgentConfig(
+        base_url=config.base_url,
+        model=get_agent_model("homeassistant", config),
+        embedding=config.embedding,
+    )
+
     # Combine worker tool rules with MCP-specific rules
     all_tool_rules = WORKER_TOOL_RULES + (mcp_tool_rules or [])
 
     agent, was_created = find_or_create_agent(
         client,
         name="HomeAssistantAgent",
-        config=config,
+        config=agent_config,
         memory_blocks=[
             {"label": "persona", "value": PERSONA},
             {"label": "human", "value": HUMAN},

--- a/agents/personal_assistant.py
+++ b/agents/personal_assistant.py
@@ -17,6 +17,7 @@ from .config import (
     AgentConfig,
     SharedResources,
     SUPERVISOR_TOOL_RULES,
+    get_agent_model,
     get_broadcast_tool,
     find_or_create_agent,
     ensure_archive_attached,
@@ -470,6 +471,13 @@ def create_personal_assistant(
     Returns:
         Tuple of (agent, was_created)
     """
+    # Resolve per-agent model override (falls back to config.model if LETTA_MODEL_PA is not set)
+    agent_config = AgentConfig(
+        base_url=config.base_url,
+        model=get_agent_model("pa", config),
+        embedding=config.embedding,
+    )
+
     # Get the multi-agent broadcast tool for tag-based routing
     broadcast_tool = get_broadcast_tool(client)
 
@@ -492,7 +500,7 @@ def create_personal_assistant(
     agent, was_created = find_or_create_agent(
         client,
         name="PersonalAssistant",
-        config=config,
+        config=agent_config,
         memory_blocks=[
             {"label": "persona", "value": PERSONA},
             {"label": "human", "value": HUMAN},

--- a/agents/research_agent.py
+++ b/agents/research_agent.py
@@ -11,6 +11,7 @@ from .config import (
     AgentConfig,
     SharedResources,
     WORKER_TOOL_RULES,
+    get_agent_model,
     find_or_create_agent,
     ensure_archive_attached,
 )
@@ -91,13 +92,20 @@ def create_research_agent(
     Returns:
         Tuple of (agent, was_created)
     """
+    # Resolve per-agent model override (falls back to config.model if LETTA_MODEL_RESEARCH is not set)
+    agent_config = AgentConfig(
+        base_url=config.base_url,
+        model=get_agent_model("research", config),
+        embedding=config.embedding,
+    )
+
     # Combine worker tool rules with MCP-specific rules
     all_tool_rules = WORKER_TOOL_RULES + (mcp_tool_rules or [])
 
     agent, was_created = find_or_create_agent(
         client,
         name="ResearchAgent",
-        config=config,
+        config=agent_config,
         memory_blocks=[
             {"label": "persona", "value": PERSONA},
             {"label": "human", "value": HUMAN},

--- a/agents/task_agent.py
+++ b/agents/task_agent.py
@@ -12,6 +12,7 @@ from .config import (
     AgentConfig,
     SharedResources,
     WORKER_TOOL_RULES,
+    get_agent_model,
     find_or_create_agent,
     ensure_archive_attached,
 )
@@ -90,13 +91,20 @@ def create_task_agent(
     Returns:
         Tuple of (agent, was_created)
     """
+    # Resolve per-agent model override (falls back to config.model if LETTA_MODEL_TASK is not set)
+    agent_config = AgentConfig(
+        base_url=config.base_url,
+        model=get_agent_model("task", config),
+        embedding=config.embedding,
+    )
+
     # Combine worker tool rules with MCP-specific rules
     all_tool_rules = WORKER_TOOL_RULES + (mcp_tool_rules or [])
 
     agent, was_created = find_or_create_agent(
         client,
         name="TaskAgent",
-        config=config,
+        config=agent_config,
         memory_blocks=[
             {"label": "persona", "value": PERSONA},
             {"label": "human", "value": HUMAN},


### PR DESCRIPTION
## What was broken

`config.py` defines `get_agent_model()` and documents per-agent env var overrides (`LETTA_MODEL_PA`, `LETTA_MODEL_RESEARCH`, `LETTA_MODEL_TASK`, `LETTA_MODEL_HOMEASSISTANT`) — and `env.template` has them commented out ready to use. But none of the `create_*` functions ever called `get_agent_model()`. Every agent was created with the raw `config` object, so `config.model` (the global `LETTA_MODEL`) was always used regardless of what per-agent overrides were set. **The env vars silently did nothing.**

## What the fix does

Each `create_*` function now:
1. Calls `get_agent_model(<key>, config)` to resolve the per-agent model (with automatic fallback to `config.model` if the env var is not set).
2. Constructs an `agent_config` with the resolved model.
3. Passes `agent_config` (instead of `config`) to `find_or_create_agent()`.

Files changed:
- `agents/personal_assistant.py` — key `"pa"` → `LETTA_MODEL_PA`
- `agents/research_agent.py` — key `"research"` → `LETTA_MODEL_RESEARCH`
- `agents/task_agent.py` — key `"task"` → `LETTA_MODEL_TASK`
- `agents/homeassistant_agent.py` — key `"homeassistant"` → `LETTA_MODEL_HOMEASSISTANT`
- `agents/create_all.py` — imports `get_agent_model` and prints the effective model for each agent at startup so overrides are visible

This is fully **backwards compatible** — if no per-agent env vars are set, `get_agent_model()` returns `config.model` unchanged.

## How to use

In your `.env` file, uncomment and set any per-agent override:

```dotenv
# Run cheaper models for workers, premium model for the PA
LETTA_MODEL=anthropic/claude-sonnet-4-6        # global default

LETTA_MODEL_PA=anthropic/claude-sonnet-4-6     # keep PA on Sonnet
LETTA_MODEL_RESEARCH=anthropic/claude-haiku-4-5  # cheaper for research
LETTA_MODEL_TASK=anthropic/claude-haiku-4-5      # cheaper for task
LETTA_MODEL_HOMEASSISTANT=anthropic/claude-haiku-4-5  # cheaper for HA
```

Then re-run `python -m agents.create_all` — the startup output will now show the effective model for each agent so you can confirm your overrides are applied:

```
Using model: anthropic/claude-sonnet-4-6 (global default)
  PA:            anthropic/claude-sonnet-4-6
  Research:      anthropic/claude-haiku-4-5
  Task:          anthropic/claude-haiku-4-5
  HomeAssistant: anthropic/claude-haiku-4-5
```

👾 Generated with [Letta Code](https://letta.com)