### PR TITLE
feat: auto-clean COMPLETED status entries on every PA heartbeat

### DIFF
--- a/agents/personal_assistant.py
+++ b/agents/personal_assistant.py
@@ -385,6 +385,7 @@ COORDINATION:
 - Update status when delegating: "PA: Delegating research on X to Research Agent"
 - Check status to avoid duplicate work or see what's already in progress
 - Keep the status block to 3–5 active lines max. Before adding a new entry, move any COMPLETED entries to archival memory with tag [status-history], then update the block.
+- On each heartbeat, the status block is also automatically scrubbed: any line starting with "COMPLETED:" is archived with tag [status-history] and removed. You do not need to wait for a new entry to trigger this cleanup.
 - TODO items in the Active section without [DONE] are actionable. After completing one:
   1. Mark it [DONE]
   2. Archive it to archival memory with tag [todo-history]
@@ -420,8 +421,13 @@ You will periodically receive [HEARTBEAT] messages. When you do:
    If there are actionable items, pick one and work on it.
    After completing an item: mark it [DONE], archive it to archival memory with tag
    [todo-history], then remove it from the block entirely — do not leave [DONE] items.
-3. If there are no monitoring tasks AND (the TODO block is empty OR has no actionable
-   items), stay silent.
+3. Clean up the status block: scan every line for entries starting with "COMPLETED:".
+   For each COMPLETED line found:
+   a. Call archival_memory_insert with the full line and tag [status-history].
+   b. Remove that line from the status block via core_memory_replace.
+   Keep the status block to 3–5 active (non-COMPLETED) lines max.
+4. If there are no monitoring tasks AND (the TODO block is empty OR has no actionable
+   items) AND (no COMPLETED status lines were cleaned up), stay silent.
 
 You and the user can both add items to the TODO block. When the user asks you
 to do something later, or you identify a follow-up worth tracking, add it as

--- a/letta-discord-bot-example/src/server.ts
+++ b/letta-discord-bot-example/src/server.ts
@@ -340,7 +340,12 @@ async function startHeartbeat() {
             'If there are actionable items, pick one and work on it. ' +
             'After completing an item, mark it [DONE], archive it to archival memory with tag [todo-history], ' +
             'then remove it from the block — do not leave [DONE] items in the block.\n' +
-            'If there are no monitoring tasks AND (the TODO block is empty OR has no actionable items), stay silent.'
+            'Next, clean up the status block: scan every line for entries starting with "COMPLETED:". ' +
+            'For each COMPLETED line found: (1) call archival_memory_insert with the full line and tag [status-history], ' +
+            '(2) remove that line from the status block via core_memory_replace. ' +
+            'Keep the status block to 3–5 active (non-COMPLETED) lines max.\n' +
+            'If there are no monitoring tasks AND (the TODO block is empty OR has no actionable items) ' +
+            'AND (no COMPLETED status lines were cleaned up), stay silent.'
         };
 
         console.log(`💓 Sending heartbeat to PA (agent=${AGENT_ID})`);


### PR DESCRIPTION
## Summary

- **`server.ts`**: Extends the heartbeat message with a new status-block cleanup step — the PA scans every line for `COMPLETED:` prefixes, archives each to archival memory with tag `[status-history]`, then removes those lines via `core_memory_replace`. The stay-silent condition is also updated to require no cleanup was triggered.
- **`personal_assistant.py`**: Adds step 3 to the `HEARTBEAT MESSAGES` section documenting the new cleanup lifecycle (`archival_memory_insert` → `core_memory_replace`). Adds a note to the `COORDINATION` section that heartbeat-driven cleanup runs automatically, independent of new status entries.

This mirrors the existing `[DONE]` → archive → remove pattern used for TODO items and enforces the 3–5 active lines cap called out in the COORDINATION section.

## Test plan

- [ ] Start the Discord bot with `HEARTBEAT_ENABLED=true` and an agent whose status block contains several `COMPLETED:` lines
- [ ] Wait for a heartbeat to fire; confirm the PA calls `archival_memory_insert` for each `COMPLETED:` line with tag `[status-history]`
- [ ] Confirm those lines are absent from the status block after the heartbeat
- [ ] Confirm the PA stays silent if there are no monitoring tasks, no actionable TODOs, and no `COMPLETED:` lines to clean up
- [ ] Confirm non-`COMPLETED:` lines (e.g. `IN PROGRESS:`) are left untouched

👾 Generated with [Letta Code](https://letta.com)