### PR TITLE
fix: validate LETTA_API_KEY at startup instead of falling back to placeholder

### DIFF
--- a/letta-discord-bot-example/src/messages.ts
+++ b/letta-discord-bot-example/src/messages.ts
@@ -9,9 +9,18 @@ import * as path from "path";
 // Discord message length limit
 const DISCORD_MESSAGE_LIMIT = 2000;
 
-// If the token is not set, just use a dummy value
+// Validate LETTA_API_KEY at startup — fail fast rather than silently falling back
+// to the placeholder value, which would cause confusing auth failures later.
+const LETTA_API_KEY = process.env.LETTA_API_KEY;
+if (!LETTA_API_KEY || LETTA_API_KEY === 'your_letta_api_key') {
+  throw new Error(
+    'LETTA_API_KEY environment variable is not set or still contains the placeholder value. ' +
+    'Set a valid API key in your .env file before starting the bot.'
+  );
+}
+
 const client = new Letta({
-  apiKey: process.env.LETTA_API_KEY || 'your_letta_api_key',
+  apiKey: LETTA_API_KEY,
   baseURL: process.env.LETTA_BASE_URL || 'https://api.letta.com',
 });
 const AGENT_ID = process.env.LETTA_AGENT_ID;

--- a/letta-discord-bot-example/src/server.ts
+++ b/letta-discord-bot-example/src/server.ts
@@ -323,8 +323,10 @@ async function startHeartbeat() {
         }
 
         const Letta = (await import('@letta-ai/letta-client')).default;
+        // LETTA_API_KEY is validated at startup in messages.ts (imported above);
+        // use a non-null assertion here since we know it is set.
         const lettaClient = new Letta({
-          apiKey: process.env.LETTA_API_KEY || 'your_letta_api_key',
+          apiKey: process.env.LETTA_API_KEY!,
           baseURL: process.env.LETTA_BASE_URL || 'http://localhost:8283',
         });
 


### PR DESCRIPTION
Fixes #21

## Problem

Both `messages.ts` and `server.ts` used the pattern:

```ts
apiKey: process.env.LETTA_API_KEY || 'your_letta_api_key',
```

If `LETTA_API_KEY` is unset (or accidentally left as the template placeholder), the
Letta client starts up silently with a bogus key. The bot appears to launch fine, then
produces confusing 401 / authentication errors that are hard to trace back to a missing
env var.

## Fix

### `messages.ts`
- Removed the `|| 'your_letta_api_key'` fallback.
- Added a module-level guard that **throws at startup** if the key is missing or is
  still the placeholder string, with a clear message pointing to `.env`.
- The validated value is stored in a local constant and passed directly to `new Letta()`.

### `server.ts`
- The heartbeat handler's dynamic `new Letta()` now uses `process.env.LETTA_API_KEY!`
  (TypeScript non-null assertion).  Because `messages.ts` is imported at startup and
  validates the key before any code runs, the assertion is safe — the process would have
  already exited with a descriptive error if the key were absent.

## Behaviour change

| Scenario | Before | After |
|---|---|---|
| `LETTA_API_KEY` unset | Bot starts, fails silently with 401 on first API call | Bot exits immediately with clear error message |
| `LETTA_API_KEY=your_letta_api_key` | Same silent failure | Same fast-fail error |
| `LETTA_API_KEY` valid | Normal | Normal (no behaviour change) |

## Testing
- [ ] Start the bot with `LETTA_API_KEY` unset — confirm it exits immediately with the new error message
- [ ] Start with `LETTA_API_KEY=your_letta_api_key` — confirm same fast-fail
- [ ] Start with a valid key — confirm normal startup and operation
- [ ] `npx tsc --noEmit` in `letta-discord-bot-example/` passes cleanly

👾 Generated with [Letta Code](https://letta.com)